### PR TITLE
Fixes regex bug on non utf-8 pages.

### DIFF
--- a/wcc.rb
+++ b/wcc.rb
@@ -109,9 +109,6 @@ class Conf
 	
 	# aliases for Conf.instance.options[:option]
 	def self.dir; Conf.instance.options[:dir] end
-	def self.debug?; Conf.instance.options[:debug] end
-	def self.verbose?; (Conf.instance.options[:verbose] and !self.quiet?) or self.debug? end
-	def self.quiet?; Conf.instance.options[:quiet] and !self.debug? end
 	def self.simulate?; Conf.instance.options[:simulate] end
 	def self.tag; Conf.instance.options[:tag] end
 	def self.send_mails?; !Conf.instance.options[:nomails] end
@@ -138,6 +135,7 @@ class Site
 	
 	def to_s; "%s;%s;%s" % [@uri.to_s, (@striphtml ? 'yes' : 'no'), @emails.join(';')] end
 	
+	# invalid hashes are nil and "" - nil.to_s is ""
 	def new?; self.hash.to_s.empty? end
 	def hash; @hash.to_s end
 	def content; load_content if @content.nil?; @content end

--- a/wcc.rb
+++ b/wcc.rb
@@ -198,8 +198,22 @@ def checkForUpdate(site)
 	new_site = res.body
 	new_hash = Digest::MD5.hexdigest(res.body)
 	
-	# detect encoding from http header (default utf-8)
-	enc = res['content-type'].to_s.match(/;\s*charset=([A-Za-z0-9-]*)/).to_a[1].downcase || 'utf-8'
+	# assume utf-8 default
+	enc = 'utf-8'
+
+	# detect encoding from http header - overrides all
+	re1 = Regexp.new(';\s*charset=([A-Za-z0-9-]*)', Regexp::IGNORECASE, 'u')
+	match = res['content-type'].to_s.match(re1)
+	if match != nil
+		enc = match[1].downcase
+	else
+		# detect encoding from <meta> tag
+		re2 = Regexp.new('<meta.*charset=([a-zA-Z0-9-]*).*', Regexp::IGNORECASE, 'u')
+		match = new_site.match(re2)
+		if match != nil
+			enc = match[1].downcase
+		end
+	end
 	
 	$logger.info "Encoding is '#{enc}'"
 	


### PR DESCRIPTION
- Fixes bug that prevent encoding detection on non UTF-8 pages on Ruby 1.9 and raise an Encoding::CompatibilityError exception.
- Compact encoding detection source code.
